### PR TITLE
Update maven_archetype.md

### DIFF
--- a/content/docs/maven_archetype.md
+++ b/content/docs/maven_archetype.md
@@ -23,14 +23,6 @@ Move into the myProject folder, and test the project:
 ~~~
 %> cd myProject
 ~~~
-Open **pom.xml** and change: (It's a bug, which will be fixed in next release.)
-~~~
-<graphwalker.version>3.2.0-SNAPSHOT</graphwalker.version>
-~~~
-to
-~~~
-<graphwalker.version>3.2.1</graphwalker.version>
-~~~
 Now, run a test:
 ~~~
 %> mvn graphwalker:test


### PR DESCRIPTION
This information seems out of date, no?
`graphwalker.version` was at version 3.3.0 for me and I didn't have to change anything in `pom.xml`